### PR TITLE
get_kubeadmin_token: pass `hide_log_command` to run_command 

### DIFF
--- a/openshift_cli_installer/utils/clusters.py
+++ b/openshift_cli_installer/utils/clusters.py
@@ -220,7 +220,8 @@ def get_kubeadmin_token(cluster_data):
     run_command(
         shlex.split(
             f"oc login {cluster_data['api-url']} -u kubeadmin -p {kubeadmin_password}"
-        )
+        ),
+        hide_log_command=True,
     )
     yield run_command(shlex.split("oc whoami -t"))[1].strip()
     run_command(shlex.split("oc logout"))


### PR DESCRIPTION
In order to prevent `kubeadmin` password in the command log

depends on https://github.com/RedHatQE/openshift-python-utilities/pull/276