### PR TITLE
get_kubeadmin_token: add `hide_log_command` option to oc command

### DIFF
--- a/openshift_cli_installer/utils/clusters.py
+++ b/openshift_cli_installer/utils/clusters.py
@@ -223,5 +223,8 @@ def get_kubeadmin_token(cluster_data):
         ),
         hide_log_command=True,
     )
-    yield run_command(shlex.split("oc whoami -t"))[1].strip()
+    yield run_command(
+        shlex.split("oc whoami -t"),
+        hide_log_command=True,
+    )[1].strip()
     run_command(shlex.split("oc logout"))


### PR DESCRIPTION
Add `hide_log_command` option to `oc whoami -t` command to prevent printing token in the logs