### PR TITLE
Add `log-level` option for AWS IPI openshift-installer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ podman run quay.io/redhat_msi/openshift-cli-installer \
     --registry-config-file=registry-config.json \
     --s3-bucket-name=openshift-cli-installer \
     --s3-bucket-path=install-folders \
-    --cluster 'name=ipi1;base_domain=aws.interop.ccitredhat.com;platform=aws;region=us-east-2;version=4.14.0-ec.2;worker_flavor=m5.xlarge;log-level=error'
+    --cluster 'name=ipi1;base_domain=aws.interop.ccitredhat.com;platform=aws;region=us-east-2;version=4.14.0-ec.2;worker_flavor=m5.xlarge;log_level=info'
 ```
-  * Pass `log-level=error` to cluster config if user want to hide the openshift-installer logs which contains `kubeadmin` password. 
+  * Default `log_level=error` is set for cluster config to hide the openshift-installer logs which contains kubeadmin password.
 
 ##### ROSA cluster
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ podman run quay.io/redhat_msi/openshift-cli-installer \
     --registry-config-file=registry-config.json \
     --s3-bucket-name=openshift-cli-installer \
     --s3-bucket-path=install-folders \
-    --cluster 'name=ipi1;base_domain=aws.interop.ccitredhat.com;platform=aws;region=us-east-2;version=4.14.0-ec.2;worker_flavor=m5.xlarge'
+    --cluster 'name=ipi1;base_domain=aws.interop.ccitredhat.com;platform=aws;region=us-east-2;version=4.14.0-ec.2;worker_flavor=m5.xlarge;log-level=error'
 ```
+  * Pass `log-level=error` to cluster config if user want to hide the openshift-installer logs which contains `kubeadmin` password. 
 
 ##### ROSA cluster
 

--- a/openshift_cli_installer/libs/unmanaged_clusters/aws_ipi_clusters.py
+++ b/openshift_cli_installer/libs/unmanaged_clusters/aws_ipi_clusters.py
@@ -241,7 +241,7 @@ def run_aws_installer_command(cluster_data, action, raise_on_failure):
         command=shlex.split(
             f"{cluster_data['openshift-install-binary']} {action} cluster --dir"
             f" {cluster_data['install-dir']}"
-            f" --log-level cluster_data.get('log-level', 'info')"
+            f" --log-level {cluster_data.get('log_level', 'error')}"
         ),
         capture_output=False,
         check=False,

--- a/openshift_cli_installer/libs/unmanaged_clusters/aws_ipi_clusters.py
+++ b/openshift_cli_installer/libs/unmanaged_clusters/aws_ipi_clusters.py
@@ -241,6 +241,7 @@ def run_aws_installer_command(cluster_data, action, raise_on_failure):
         command=shlex.split(
             f"{cluster_data['openshift-install-binary']} {action} cluster --dir"
             f" {cluster_data['install-dir']}"
+            f" --log-level cluster_data.get('log-level', 'info')"
         ),
         capture_output=False,
         check=False,

--- a/openshift_cli_installer/libs/user_input.py
+++ b/openshift_cli_installer/libs/user_input.py
@@ -131,7 +131,7 @@ class UserInput:
             self.is_platform_supported()
             self.assert_unique_cluster_names()
             self.assert_managed_acm_clusters_user_input()
-
+            self.assert_aws_ipi_installer_log_level_user_input()
             self.assert_aws_ipi_user_input()
             self.assert_aws_osd_user_input()
             self.assert_acm_clusters_user_input()
@@ -205,6 +205,24 @@ class UserInput:
 
             self.assert_public_ssh_key_file_exists()
             self.assert_registry_config_file_exists()
+
+    def assert_aws_ipi_installer_log_level_user_input(self):
+        supported_log_levels = ["debug", "info", "warn", "error"]
+        unsupported_log_levels = []
+        for _cluster in self.clusters:
+            if _cluster["platform"] == AWS_STR:
+                log_level = _cluster.get("log_level", "error")
+                if log_level not in supported_log_levels:
+                    unsupported_log_levels.append(
+                        f"LogLevel {log_level} for cluster {_cluster['name']}"
+                    )
+
+        if unsupported_log_levels:
+            self.logger.error(
+                f"{unsupported_log_levels} not supported for openshift-installer cli."
+                f" Supported options are {supported_log_levels}"
+            )
+            raise click.Abort()
 
     def assert_public_ssh_key_file_exists(self):
         if not self.ssh_key_file or not os.path.exists(self.ssh_key_file):

--- a/openshift_cli_installer/manifests/clusters.example.yaml
+++ b/openshift_cli_installer/manifests/clusters.example.yaml
@@ -104,3 +104,4 @@ clusters:
   worker_replicas: 2
   worker_flavor: m5.4xlarge
   worker_root_disk_size: 128
+  log-level: info # optional, default: "info", supported options are debug, info, warn, error

--- a/openshift_cli_installer/manifests/clusters.example.yaml
+++ b/openshift_cli_installer/manifests/clusters.example.yaml
@@ -104,4 +104,4 @@ clusters:
   worker_replicas: 2
   worker_flavor: m5.4xlarge
   worker_root_disk_size: 128
-  log-level: info # optional, default: "info", supported options are debug, info, warn, error
+  log_level: info # optional, default: "error", supported options are debug, info, warn, error


### PR DESCRIPTION
Add `--log-level=error` option to `openshift-install` command for only printing logs incase of error.
This will prevent command not to print info logs with kubeadmin password.

Example logs incase of error:
```
2023-10-17T19:18:44.111026 ocp_utilities.utils INFO Running /tmp/quay.io/openshift-release-dev/ocp-release:4.13.17-x86_64/openshift-install create cluster --dir /tmp/clusters-data/aws/cchetna-ipi --log-level=error command
FATAL failed to fetch Metadata: failed to fetch dependency of "Metadata": failed to fetch dependency of "Bootstrap Ignition Config": failed to fetch dependency of "CVO Ignore": failed to fetch dependency of "Common Manifests": failed to generate asset "DNS Config": getting public zone for "aws.domain.example.com": No public route53 zone found matching name "aws.domain.example.com" 
2023-10-17T19:18:50.030810 ocp_utilities.utils ERROR Failed to run ['/tmp/quay.io/openshift-release-dev/ocp-release:4.13.17-x86_64/openshift-install', 'create', 'cluster', '--dir', '/tmp/clusters-data/aws/cchetna-ipi', '--log-level=error']. rc: 1, out: None, error: None
Failed to run cluster create for cluster cchetna-ipi
        ERR: None
        OUT: None.
Upload /tmp/clusters-data/aws/cchetna-ipi-ithkYr3jRCKRjfx77XP3Bn.zip file to S3 openshift-cli-installer, path openshift-ci/cchetna-ipi-ithkYr3jRCKRjfx77XP3Bn.zip
```

Example logs in case of cluster creation:
```
2023-10-17T19:22:13.481958 ocp_utilities.utils INFO Running /tmp/quay.io/openshift-release-dev/ocp-release:4.13.17-x86_64/openshift-install create cluster --dir /tmp/clusters-data/aws/cchetna-ipi --log-level=error command
2023-10-17T19:55:22.093593 ocp_utilities.infra INFO Trying to get client via new_client_from_config
2023-10-17T19:55:23.954324 ocp_resources.resource INFO kind: Route api version: route.openshift.io/v1
Cluster cchetna-ipi created successfully
Upload /tmp/clusters-data/aws/cchetna-ipi-iTEuXDCD5K4P4HmTj2avKv.zip file to S3 openshift-cli-installer, path openshift-ci/cchetna-ipi-iTEuXDCD5K4P4HmTj2avKv.zip
```
