### PR TITLE
Support destroy clusters from s3 bucket using cluster_data.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,10 @@ Attach clusters to ACM cluster hub:
 `--destroy-clusters-from-install-data-directory`, `--destroy-clusters-from-s3-bucket` and `--destroy-clusters-from-install-data-directory-using-s3-bucket` must have:
 
 ```bash
---ocm-token=$OCM_TOKEN \
-  --ssh-key-file=${HOME}/.ssh/id_rsa.pub \
+  --ocm-token=$OCM_TOKEN \
   --registry-config-file=${HOME}/docker-secrets.json \
   --aws-access-key-id=${AWS_ACCESS_KEY_ID} \
-  --aws-secret-access-key=${AWS_SECRET_ACCESS_KEY} \
-  --aws-account-id=${AWS_ACCOUNT_ID} \
-  --clusters-install-data-directory=/tmp/clusters-destroy
+  --aws-secret-access-key=${AWS_SECRET_ACCESS_KEY}
 ```
 
 ## Destroy clusters from clusters data directory

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Attach clusters to ACM cluster hub:
 
 ### Destroy clusters
 
-Both `--destroy-clusters-from-install-data-directory` and `--destroy-clusters-from-s3-bucket` must have:
+`--destroy-clusters-from-install-data-directory`, `--destroy-clusters-from-s3-bucket` and `--destroy-clusters-from-install-data-directory-using-s3-bucket` must have:
 
 ```bash
 --ocm-token=$OCM_TOKEN \
@@ -111,6 +111,13 @@ To destroy all clusters locate in `--clusters-install-data-directory` run:
 ```bash
 podman run quay.io/redhat_msi/openshift-cli-installer \
   --destroy-clusters-from-install-data-directory \
+  --clusters-install-data-directory=/openshift-cli-installer/clusters-install-data
+```
+
+## Destroy clusters from clusters data directory using s3 bucket stored in cluster_data.yaml
+```bash
+podman run quay.io/redhat_msi/openshift-cli-installer \
+  --destroy-clusters-from-install-data-directory-using-s3-bucket \
   --clusters-install-data-directory=/openshift-cli-installer/clusters-install-data
 ```
 

--- a/openshift_cli_installer/cli.py
+++ b/openshift_cli_installer/cli.py
@@ -158,6 +158,16 @@ Destroy clusters from cluster data files located at --clusters-install-data-dire
     is_flag=True,
 )
 @click.option(
+    "--destroy-clusters-from-install-data-directory-using-s3-bucket",
+    help="""
+\b
+Destroy clusters from cluster data files located at --clusters-install-data-directory
+Get the S3 object from cluster_data.yaml, download, extract it and call destroy cluster
+    """,
+    show_default=True,
+    is_flag=True,
+)
+@click.option(
     "--clusters-yaml-config-file",
     help="""
     \b
@@ -207,6 +217,7 @@ def main(**kwargs):
     if (
         kwargs["destroy_clusters_from_s3_bucket"]
         or kwargs["destroy_clusters_from_install_data_directory"]
+        or kwargs["destroy_clusters_from_install_data_directory_using_s3_bucket"]
     ):
         clusters_kwargs = destroy_clusters_from_s3_bucket_or_local_directory(**kwargs)
 

--- a/openshift_cli_installer/libs/clusters/ocp_cluster.py
+++ b/openshift_cli_installer/libs/clusters/ocp_cluster.py
@@ -85,13 +85,18 @@ class OCPCluster(UserInput):
 
         self.version = self.cluster["version"]
         self.stream = get_cluster_stream(cluster_data=self.cluster)
-        self.cluster_dir = os.path.join(
-            self.clusters_install_data_directory, self.platform, self.name
-        )
+
+        self.cluster_dir = self.cluster.get("cluster_dir")
+        if not self.cluster_dir:
+            self.cluster_dir = os.path.join(
+                self.clusters_install_data_directory, self.platform, self.name
+            )
+            self.cluster["cluster_dir"] = self.cluster_dir
+
         self.auth_path = os.path.join(self.cluster_dir, "auth")
         self.kubeconfig_path = os.path.join(self.auth_path, "kubeconfig")
-
         Path(self.auth_path).mkdir(parents=True, exist_ok=True)
+
         self._add_s3_bucket_data()
 
         self.dump_cluster_data_to_file()
@@ -172,6 +177,9 @@ class OCPCluster(UserInput):
         )
 
     def dump_cluster_data_to_file(self):
+        if not self.create:
+            return
+
         _cluster_data = {}
         keys_to_pop = (
             "ocm_client",
@@ -215,6 +223,7 @@ class OCPCluster(UserInput):
             "cidr",
             "hosted_cp",
             "_already_processed",
+            "cluster_dir",
         )
         for _key, _val in self.to_dict.items():
             if _key in keys_to_pop or not _val:

--- a/openshift_cli_installer/libs/clusters/rosa_cluster.py
+++ b/openshift_cli_installer/libs/clusters/rosa_cluster.py
@@ -98,8 +98,8 @@ class RosaCluster(OcmCluster):
         )
 
     def destroy_hypershift_vpc(self):
-        self.logger.info(f"{self.log_prefix}: Destroy hypershift VPCs")
         self.terraform_init()
+        self.logger.info(f"{self.log_prefix}: Destroy hypershift VPCs")
         rc, _, err = self.terraform.destroy(
             force=IsNotFlagged,
             auto_approve=True,
@@ -113,8 +113,8 @@ class RosaCluster(OcmCluster):
             raise click.Abort()
 
     def prepare_hypershift_vpc(self):
-        self.logger.info(f"{self.log_prefix}: Preparing hypershift VPCs")
         self.terraform_init()
+        self.logger.info(f"{self.log_prefix}: Preparing hypershift VPCs")
         shutil.copy(
             os.path.join(get_manifests_path(), "setup-vpc.tf"), self.cluster_dir
         )

--- a/openshift_cli_installer/libs/user_input.py
+++ b/openshift_cli_installer/libs/user_input.py
@@ -65,6 +65,11 @@ class UserInput:
         self.destroy_clusters_from_install_data_directory = self.user_kwargs.get(
             "destroy_clusters_from_install_data_directory"
         )
+        self.destroy_clusters_from_install_data_directory_using_s3_bucket = (
+            self.user_kwargs.get(
+                "destroy_clusters_from_install_data_directory_using_s3_bucket"
+            )
+        )
         self.registry_config_file = self.user_kwargs.get("registry_config_file")
         self.ssh_key_file = self.user_kwargs.get("ssh_key_file")
         self.docker_config_file = self.user_kwargs.get("docker_config_file")
@@ -123,8 +128,16 @@ class UserInput:
                 )
                 raise click.Abort()
 
-        elif self.destroy_clusters_from_install_data_directory:
-            return
+        elif (
+            self.destroy_clusters_from_install_data_directory
+            and self.destroy_clusters_from_install_data_directory_using_s3_bucket
+        ):
+            self.logger.error(
+                "`--destroy-clusters-from-install-data-directory-using-s3-bucket` is"
+                " not supported when running with"
+                " `--destroy-clusters-from-install-data-directory`",
+            )
+            raise click.Abort()
 
         else:
             if not self.action:

--- a/openshift_cli_installer/libs/user_input.py
+++ b/openshift_cli_installer/libs/user_input.py
@@ -238,8 +238,10 @@ class UserInput:
                 )
                 raise click.Abort()
 
-            self.assert_public_ssh_key_file_exists()
             self.assert_registry_config_file_exists()
+
+            if self.create:
+                self.assert_public_ssh_key_file_exists()
 
     def assert_aws_ipi_installer_log_level_user_input(self):
         supported_log_levels = ["debug", "info", "warn", "error"]
@@ -280,7 +282,7 @@ class UserInput:
     def assert_aws_osd_user_input(self):
         if any([_cluster["platform"] == AWS_OSD_STR for _cluster in self.clusters]):
             self.assert_aws_credentials_exist()
-            if not self.aws_account_id:
+            if not self.aws_account_id and self.create:
                 self.logger.error(
                     "--aws-account-id required for AWS OSD installations.",
                 )

--- a/openshift_cli_installer/utils/clusters.py
+++ b/openshift_cli_installer/utils/clusters.py
@@ -66,11 +66,9 @@ def clusters_from_directories(directories):
 def get_destroy_clusters_kwargs(clusters_data_list, **kwargs):
     kwargs["action"] = DESTROY_STR
 
-    for cluster in clusters_data_list:
-        _cluster = cluster.pop("cluster", {})
-        _cluster.pop("expiration-time", None)
-        if _cluster:
-            kwargs.setdefault("clusters", []).append(_cluster)
+    for cluster_data_from_yaml in clusters_data_list:
+        cluster_data_from_yaml["cluster"].pop("expiration-time", None)
+        kwargs.setdefault("clusters", []).append(cluster_data_from_yaml["cluster"])
 
     return kwargs
 
@@ -151,6 +149,7 @@ def get_all_zip_files_from_s3_bucket(
 def destroy_clusters_from_s3_bucket_or_local_directory(**kwargs):
     s3_clusters_data_list = []
     data_directory_clusters_data_list = []
+
     s3_from_clusters_data_directory = kwargs[
         "destroy_clusters_from_install_data_directory_using_s3_bucket"
     ]

--- a/openshift_cli_installer/utils/clusters.py
+++ b/openshift_cli_installer/utils/clusters.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import os
 import shlex
 import shutil
@@ -63,25 +64,15 @@ def clusters_from_directories(directories):
 
 
 def get_destroy_clusters_kwargs(clusters_data_list, **kwargs):
-    clusters_kwargs = {
-        "action": DESTROY_STR,
-        "ocm_token": kwargs.get("ocm_token"),
-        "docker_config_file": kwargs.get("docker_config_file"),
-        "ssh_key_file": kwargs.get("ssh_key_file"),
-        "registry_config_file": kwargs.get("registry_config_file"),
-        "aws_secret_access_key": kwargs.get("aws_secret_access_key"),
-        "aws_access_key_id": kwargs.get("aws_access_key_id"),
-        "aws_account_id": kwargs.get("aws_account_id"),
-        "clusters_install_data_directory": kwargs.get(
-            "clusters_install_data_directory"
-        ),
-    }
+    kwargs["action"] = DESTROY_STR
+
     for cluster in clusters_data_list:
         _cluster = cluster.pop("cluster", {})
         _cluster.pop("expiration-time", None)
-        clusters_kwargs.setdefault("clusters", []).append(_cluster)
+        if _cluster:
+            kwargs.setdefault("clusters", []).append(_cluster)
 
-    return clusters_kwargs
+    return kwargs
 
 
 def prepare_clusters_directory_from_s3_bucket(**kwargs):
@@ -158,22 +149,42 @@ def get_all_zip_files_from_s3_bucket(
 
 
 def destroy_clusters_from_s3_bucket_or_local_directory(**kwargs):
-    cluster_install_data_directory = kwargs["clusters_install_data_directory"]
-    destroy_clusters_from_s3_bucket = kwargs["destroy_clusters_from_s3_bucket"]
+    s3_clusters_data_list = []
+    data_directory_clusters_data_list = []
+    s3_from_clusters_data_directory = kwargs[
+        "destroy_clusters_from_install_data_directory_using_s3_bucket"
+    ]
     destroy_clusters_from_install_data_directory = kwargs[
         "destroy_clusters_from_install_data_directory"
     ]
-    clusters_data_list = []
-    if destroy_clusters_from_s3_bucket:
-        clusters_data_list.extend(prepare_clusters_directory_from_s3_bucket(**kwargs))
-
-    if destroy_clusters_from_install_data_directory:
-        clusters_data_list.extend(
-            clusters_from_directories(directories=[cluster_install_data_directory])
+    if kwargs["destroy_clusters_from_s3_bucket"]:
+        s3_clusters_data_list.extend(
+            prepare_clusters_directory_from_s3_bucket(**kwargs)
         )
 
+    if destroy_clusters_from_install_data_directory or s3_from_clusters_data_directory:
+        clusters_from_directory = clusters_from_directories(
+            directories=[kwargs["clusters_install_data_directory"]]
+        )
+        if destroy_clusters_from_install_data_directory:
+            data_directory_clusters_data_list.extend(clusters_from_directory)
+
+        elif s3_from_clusters_data_directory:
+            copy_kwargs = copy.deepcopy(kwargs)
+            for _cluster in clusters_from_directory:
+                _s3_object_name = _cluster.get("s3_object_name")
+                _s3_bucket_name = _cluster.get("s3_bucket_name")
+                if _s3_object_name and _s3_bucket_name:
+                    copy_kwargs["s3_bucket_name"] = _s3_bucket_name
+                    copy_kwargs["s3_bucket_path"] = _cluster.get("s3_bucket_path")
+                    copy_kwargs["query"] = os.path.split(_s3_object_name)[-1]
+                    s3_clusters_data_list.extend(
+                        prepare_clusters_directory_from_s3_bucket(**copy_kwargs)
+                    )
+
     clusters_kwargs = get_destroy_clusters_kwargs(
-        clusters_data_list=clusters_data_list, **kwargs
+        clusters_data_list=s3_clusters_data_list + data_directory_clusters_data_list,
+        **kwargs,
     )
     if not clusters_kwargs.get("clusters"):
         LOGGER.error("No clusters to destroy")


### PR DESCRIPTION
Destroy clusters using s3 bucket locate in cluster_data.yaml file.
pass `--destroy-clusters-from-install-data-directory-using-s3-bucket`, this will get all s3 buckets from `--clusters-install-data-directory`  cluster_data.yaml for each cluster in the directories, extract it and run destroy cluster.
