### PR TITLE
Add `s3_bucket_name` and `s3_bucket_path` to `cluster_info`

### DIFF
--- a/openshift_cli_installer/libs/clusters/ocp_cluster.py
+++ b/openshift_cli_installer/libs/clusters/ocp_cluster.py
@@ -49,8 +49,8 @@ class OCPCluster(UserInput):
         destroy_from_s3_bucket_or_local_directory = kwargs.get("destroy_from_s3_bucket_or_local_directory")
         if destroy_from_s3_bucket_or_local_directory:
             self.cluster_info = self.cluster["cluster_info"]
-            self.s3_bucket_name = self.cluster["cluster_info"]["s3_bucket_name"]
-            self.s3_bucket_path = self.cluster["cluster_info"]["s3_bucket_path"]
+            self.s3_bucket_name = self.s3_bucket_name or self.cluster["cluster_info"].get("s3_bucket_name")
+            self.s3_bucket_path = self.s3_bucket_path or self.cluster["cluster_info"].get("s3_bucket_path")
         else:
             self.cluster_info = copy.deepcopy(self.cluster)
 

--- a/openshift_cli_installer/libs/clusters/ocp_cluster.py
+++ b/openshift_cli_installer/libs/clusters/ocp_cluster.py
@@ -49,6 +49,8 @@ class OCPCluster(UserInput):
         destroy_from_s3_bucket_or_local_directory = kwargs.get("destroy_from_s3_bucket_or_local_directory")
         if destroy_from_s3_bucket_or_local_directory:
             self.cluster_info = self.cluster["cluster_info"]
+            self.s3_bucket_name = self.cluster["cluster_info"]["s3_bucket_name"]
+            self.s3_bucket_path = self.cluster["cluster_info"]["s3_bucket_path"]
         else:
             self.cluster_info = copy.deepcopy(self.cluster)
 

--- a/openshift_cli_installer/utils/clusters.py
+++ b/openshift_cli_installer/utils/clusters.py
@@ -51,7 +51,6 @@ def get_destroy_clusters_kwargs(clusters_data_list, **kwargs):
     for cluster_data_from_yaml in clusters_data_list:
         cluster_data_from_yaml["cluster"].pop("expiration-time", None)
         cluster_data_from_yaml["cluster"]["cluster_info"] = cluster_data_from_yaml["cluster_info"]
-
         kwargs.setdefault("clusters", []).append(cluster_data_from_yaml["cluster"])
 
     return kwargs

--- a/openshift_cli_installer/utils/clusters.py
+++ b/openshift_cli_installer/utils/clusters.py
@@ -37,6 +37,8 @@ def clusters_from_directories(directories):
                         _data = yaml.safe_load(fd)
 
                     _data["cluster_info"]["cluster-dir"] = root
+                    _data["cluster_info"]["s3_bucket_name"] = _data.get("s3_bucket_name")
+                    _data["cluster_info"]["s3_bucket_path"] = _data.get("s3_bucket_path")
 
                     clusters_data_list.append(_data)
 
@@ -49,6 +51,7 @@ def get_destroy_clusters_kwargs(clusters_data_list, **kwargs):
     for cluster_data_from_yaml in clusters_data_list:
         cluster_data_from_yaml["cluster"].pop("expiration-time", None)
         cluster_data_from_yaml["cluster"]["cluster_info"] = cluster_data_from_yaml["cluster_info"]
+
         kwargs.setdefault("clusters", []).append(cluster_data_from_yaml["cluster"])
 
     return kwargs


### PR DESCRIPTION
When destroying clusters from directories, `s3_bucket_name` and `s3_bucket_path` should be taken from cluster_data.yaml file and not from cli