### PR TITLE
Build command tests

### DIFF
--- a/openshift_cli_installer/scripts/openshift-cli-installer-build-command.py
+++ b/openshift_cli_installer/scripts/openshift-cli-installer-build-command.py
@@ -13,11 +13,11 @@ def main():
         cmd += " --parallel"
 
     if os_env.get("CLUSTER1"):
-        clusters += f" -c '{os_env['CLUSTER1']}'"
+        clusters += f" --cluster '{os_env['CLUSTER1']}'"
     if os_env.get("CLUSTER2"):
-        clusters += f" -c '{os_env['CLUSTER2']}'"
+        clusters += f" --cluster '{os_env['CLUSTER2']}'"
     if os_env.get("CLUSTER3"):
-        clusters += f" -c '{os_env['CLUSTER3']}'"
+        clusters += f" --cluster '{os_env['CLUSTER3']}'"
 
     cmd += f" {clusters}"
 

--- a/openshift_cli_installer/tests/test_build_command_script.py
+++ b/openshift_cli_installer/tests/test_build_command_script.py
@@ -14,7 +14,7 @@ def user_options():
                 if deco.func.attr != "option":
                     continue
 
-                user_options.append([i.n for i in deco.args if i.n.startswith("--")][0])
+                user_options.append([_arg.n for _arg in deco.args if _arg.n.startswith("--")][0])
     return user_options
 
 

--- a/openshift_cli_installer/tests/test_build_command_script.py
+++ b/openshift_cli_installer/tests/test_build_command_script.py
@@ -1,0 +1,32 @@
+import ast
+import pytest
+
+
+@pytest.fixture()
+def user_options():
+    user_options = []
+    with open("openshift_cli_installer/cli.py", "r") as fd:
+        tree = ast.parse(fd.read())
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            for deco in node.decorator_list:
+                if deco.func.attr != "option":
+                    continue
+
+                user_options.append([i.n for i in deco.args if i.n.startswith("--")][0])
+    return user_options
+
+
+@pytest.fixture()
+def build_command_script():
+    with open("openshift_cli_installer/scripts/openshift-cli-installer-build-command.py", "r") as fd:
+        return fd.read()
+
+
+def test_build_command_script(user_options, build_command_script):
+    for user_option in user_options:
+        if user_option in ("--dry-run", "--pdb"):
+            continue
+
+        assert user_option in build_command_script, f"User option {user_option} should be in build command script"


### PR DESCRIPTION
Add tests to `openshift-cli-installer-build-command.py` to make sure we cover new click options when added.
