### PR TITLE
Support cluster name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Action also can be passed to the CLI as `--action create/destroy` instead of spe
 Every call to the openshift installer cli must have at least one `--cluster` option.  
 
 * Mandatory parameters:
-  * name: The name of the cluster
+  * name or name-prefix: The name of the cluster or the prefix of the name of the cluster, if prefix is used we generate a unique name up to 15 characters.
   * platform: The platform to deploy the cluster on (supported platforms are: aws, rosa and hypershift)
   * region: The region to deploy the cluster. Optional for AWS-IPI and AWS-OSD clusters, but mandatory for other (GCP, ROSA, Hypershift) clusters.
 * Optional parameters:

--- a/openshift_cli_installer/libs/user_input.py
+++ b/openshift_cli_installer/libs/user_input.py
@@ -151,6 +151,7 @@ class UserInput:
                 raise click.Abort()
 
             self.is_platform_supported()
+            self.assert_cluster_name()
             self.assert_unique_cluster_names()
             self.assert_managed_acm_clusters_user_input()
             self.assert_ipi_installer_user_input()
@@ -187,7 +188,7 @@ class UserInput:
 
     def assert_unique_cluster_names(self):
         if self.create:
-            cluster_names = [cluster["name"] for cluster in self.clusters]
+            cluster_names = [cluster.get("name") for cluster in self.clusters if cluster.get("name") is not None]
             if len(cluster_names) != len(set(cluster_names)):
                 self.logger.error(f"Cluster names must be unique: clusters {cluster_names}")
                 raise click.Abort()
@@ -349,3 +350,9 @@ class UserInput:
                 missing_storage_data.append(f"{base_error_str} is missing" " `acm-observability-s3-secret-access-key`")
 
         return missing_storage_data
+
+    def assert_cluster_name(self):
+        for cluster in self.clusters:
+            if not cluster.get("name", cluster.get("name-prefix")):
+                self.logger.error("Cluster name or name_prefix must be provided")
+                raise click.Abort()

--- a/openshift_cli_installer/manifests/clusters.example.yaml
+++ b/openshift_cli_installer/manifests/clusters.example.yaml
@@ -15,7 +15,7 @@ must_gather_output_dir: null
 
 clusters:
 # AWS OSD cluster
-- name: aws-osd-c1
+- name: aws-osd-c1  # name-prefix can be passed instead of name
   platform: aws-osd
   region: us-east-2
   version: "4.13"


### PR DESCRIPTION
Add option to send `--name-prefix` for cluster instead of `--name`.
If `name-prefix` pass, a unique name will be generated up to 15 characters for the cluster.
