### PR TITLE
Fix s3 object deletion and remove exit on vpc deletion failure

### DIFF
--- a/openshift_cli_installer/libs/clusters/ocp_cluster.py
+++ b/openshift_cli_installer/libs/clusters/ocp_cluster.py
@@ -112,7 +112,8 @@ class OCPCluster:
             self.cluster_info["auth-path"] = auth_path = os.path.join(cluster_dir, "auth")
             self.cluster_info["kubeconfig-path"] = os.path.join(auth_path, "kubeconfig")
             Path(auth_path).mkdir(parents=True, exist_ok=True)
-            self._add_s3_bucket_data()
+            if self.s3_bucket_name:
+                self._add_s3_bucket_data()
 
         self.log_prefix = (
             f"[C:{self.cluster_info['name']}|P:{self.cluster_info['platform']}|"
@@ -306,7 +307,7 @@ class OCPCluster:
         self.dump_cluster_data_to_file()
 
     def delete_cluster_s3_buckets(self) -> None:
-        if self.s3_bucket_name and (s3_file := self.cluster_info.get("s3-object-name")):
+        if s3_file := self.cluster_info.get("s3-object-name"):
             self.logger.info(f"{self.log_prefix}: Deleting S3 file {s3_file} from {self.s3_bucket_name}")
             s3_client().delete_object(Bucket=self.s3_bucket_name, Key=s3_file)
             self.logger.success(f"{self.log_prefix}: {s3_file} deleted ")

--- a/openshift_cli_installer/libs/clusters/ocp_cluster.py
+++ b/openshift_cli_installer/libs/clusters/ocp_cluster.py
@@ -306,7 +306,7 @@ class OCPCluster:
         self.dump_cluster_data_to_file()
 
     def delete_cluster_s3_buckets(self) -> None:
-        if s3_file := self.cluster_info.get("s3-object-name"):
+        if self.s3_bucket_name and (s3_file := self.cluster_info.get("s3-object-name")):
             self.logger.info(f"{self.log_prefix}: Deleting S3 file {s3_file} from {self.s3_bucket_name}")
             s3_client().delete_object(Bucket=self.s3_bucket_name, Key=s3_file)
             self.logger.success(f"{self.log_prefix}: {s3_file} deleted ")

--- a/openshift_cli_installer/libs/clusters/rosa_cluster.py
+++ b/openshift_cli_installer/libs/clusters/rosa_cluster.py
@@ -138,7 +138,6 @@ class RosaCluster(OcmCluster):
         )
         if rc != 0:
             self.logger.error(f"{self.log_prefix}: Failed to destroy hypershift VPCs with error: {err}")
-            raise click.Abort()
 
     def prepare_hypershift_vpc(self) -> None:
         self.terraform_init()


### PR DESCRIPTION
if s3 bucket does not exist, deletion during cluster destroy should not attempt to delete the (non-existing) s3 object