### PR TITLE
Use `.get()` to retrieve fips values

### DIFF
--- a/openshift_cli_installer/libs/clusters/ipi_cluster.py
+++ b/openshift_cli_installer/libs/clusters/ipi_cluster.py
@@ -48,7 +48,7 @@ class IpiCluster(OCPCluster):
             self.openshift_install_binary_path = ""
             self.ipi_base_available_versions: Dict[str, Dict[str, List[str]]]
             self.cluster["ocm-env"] = self.cluster_info["ocm-env"] = PRODUCTION_STR
-        if self.cluster_info["fips"]:
+        if self.cluster_info.get("fips"):
             os.environ["OPENSHIFT_INSTALL_SKIP_HOSTCRYPT_VALIDATION"] = "true"
 
     def _prepare_ipi_cluster(self) -> None:
@@ -66,7 +66,7 @@ class IpiCluster(OCPCluster):
             self._create_install_config_file()
 
     def _ipi_download_installer(self) -> None:
-        openshift_install_binary = f"openshift-install{'-fips' if self.cluster_info['fips'] else ''}"
+        openshift_install_binary = f"openshift-install{'-fips' if self.cluster_info.get('fips') else ''}"
         version_url = self.cluster_info["version-url"]
         binary_dir = os.path.join(tempfile.TemporaryDirectory().name, version_url)
         self.openshift_install_binary_path = os.path.join(binary_dir, openshift_install_binary)

--- a/openshift_cli_installer/libs/clusters/ipi_cluster.py
+++ b/openshift_cli_installer/libs/clusters/ipi_cluster.py
@@ -48,7 +48,8 @@ class IpiCluster(OCPCluster):
             self.openshift_install_binary_path = ""
             self.ipi_base_available_versions: Dict[str, Dict[str, List[str]]]
             self.cluster["ocm-env"] = self.cluster_info["ocm-env"] = PRODUCTION_STR
-        if self.cluster_info.get("fips"):
+        self.fips = self.cluster_info.get("fips")
+        if self.fips:
             os.environ["OPENSHIFT_INSTALL_SKIP_HOSTCRYPT_VALIDATION"] = "true"
 
     def _prepare_ipi_cluster(self) -> None:
@@ -66,7 +67,7 @@ class IpiCluster(OCPCluster):
             self._create_install_config_file()
 
     def _ipi_download_installer(self) -> None:
-        openshift_install_binary = f"openshift-install{'-fips' if self.cluster_info.get('fips') else ''}"
+        openshift_install_binary = f"openshift-install{'-fips' if self.fips else ''}"
         version_url = self.cluster_info["version-url"]
         binary_dir = os.path.join(tempfile.TemporaryDirectory().name, version_url)
         self.openshift_install_binary_path = os.path.join(binary_dir, openshift_install_binary)


### PR DESCRIPTION
`fips` is an optional value, if it does not exist, the tool will fail.