### PR TITLE
Reuse oidc-config-id in create_oidc when provided

### DIFF
--- a/openshift_cli_installer/libs/clusters/rosa_cluster.py
+++ b/openshift_cli_installer/libs/clusters/rosa_cluster.py
@@ -86,7 +86,7 @@ class RosaCluster(OcmCluster):
             raise click.Abort()
 
     def create_oidc(self) -> None:
-        existing = self.cluster.get("oidc-config-id") or self.cluster_info.get("oidc-config-id")
+        existing = self.cluster_info.get("oidc-config-id") or self.cluster.get("oidc-config-id")
         if existing:
             self.logger.info(f"{self.log_prefix}: Reusing provided OIDC config {existing}")
             self.cluster["oidc-config-id"] = self.cluster_info["oidc-config-id"] = existing

--- a/openshift_cli_installer/libs/clusters/rosa_cluster.py
+++ b/openshift_cli_installer/libs/clusters/rosa_cluster.py
@@ -86,6 +86,12 @@ class RosaCluster(OcmCluster):
             raise click.Abort()
 
     def create_oidc(self) -> None:
+        existing = self.cluster.get("oidc-config-id") or self.cluster_info.get("oidc-config-id")
+        if existing:
+            self.logger.info(f"{self.log_prefix}: Reusing provided OIDC config {existing}")
+            self.cluster["oidc-config-id"] = self.cluster_info["oidc-config-id"] = existing
+            return
+
         self.logger.info(f"{self.log_prefix}: Create OIDC config")
         res = rosa.cli.execute(
             command="create oidc-config --managed=true",


### PR DESCRIPTION
## Summary
- Honor a caller-provided `oidc-config-id` in `RosaCluster.create_oidc()` instead of always creating a new managed OIDC config.
- Needed for ROSA HCP FIPS flows that pre-create OIDC + operator roles so trust stays aligned.


